### PR TITLE
Fix test with zig 0.13.0

### DIFF
--- a/src/builtins.zig
+++ b/src/builtins.zig
@@ -186,7 +186,7 @@ pub fn die(_: *HSH, _: *ParsedIterator) Err!u8 {
 test "fs" {
     const c = std.fs.cwd();
     // I assume this dir will always exist... but we'll see :D
-    const ndir = try c.openDir("./zig-cache", .{});
+    const ndir = try c.openDir("./.zig-cache", .{});
     try ndir.setAsCwd();
 }
 


### PR DESCRIPTION
Otherwise fails with:
```
test
+- run test 93/94 passed, 1 failed
error: 'builtins.test.fs' failed: /usr/lib/zig/std/posix.zig:1768:23: 0x11353a0 in openatZ (test)
            .NOENT => return error.FileNotFound,
                      ^
/usr/lib/zig/std/fs/Dir.zig:1564:21: 0x1115706 in openDirFlagsZ (test)
        else => |e| return e,
                    ^
/usr/lib/zig/std/fs/Dir.zig:1528:5: 0x10e2ae2 in openDirZ (test)
    return self.openDirFlagsZ(sub_path_c, symlink_flags);
    ^
/usr/lib/zig/std/fs/Dir.zig:1472:5: 0x1084dee in openDir (test)
    return self.openDirZ(&sub_path_c, args);
    ^
/build/hsh/src/hsh/src/builtins.zig:189:18: 0x1117308 in test.fs (test)
    const ndir = try c.openDir("./zig-cache", .{});
                 ^
error: while executing test 'draw.layout.test.grid 3*4 + 1', the following test command failed:
/build/hsh/src/hsh/.zig-cache/o/1943f678ae3c34f0c14315ee96211ff8/test --listen=- 
Build Summary: 2/4 steps succeeded; 1 failed; 93/94 tests passed; 1 failed (disable with --summary none)
test transitive failure
+- run test 93/94 passed, 1 failed
error: the following build command failed with exit code 1:
/build/hsh/src/hsh/.zig-cache/o/6d32512167eb1ea21ed808be9ac14656/build /usr/bin/zig /build/hsh/src/hsh /build/hsh/src/hsh/.zig-cache /build/.cache/zig --seed 0x19a7f264 -Z6a1c3df9b9fa0243 test -Dtarget=native-linux.5.15-gnu -Dcpu=baseline

```